### PR TITLE
Updated Names

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,15 +1,15 @@
 tasks:
   - init: |
       sudo docker pull registry.jetbrains.team/p/prj/containers/projector-pycharm-c
-      sudo docker pull registry.jetbrains.team/p/prj/containers/projector-pycharm-u
+      sudo docker pull registry.jetbrains.team/p/prj/containers/projector-pycharm-p
     command: |
       sudo mkdir -p .jetbrains; sudo touch .jetbrains/.gitkeep; sudo chown -R 1000:1000 .jetbrains
 
       # Community Edition
       sudo docker run --rm -p 8887:8887 -v /workspace/template-jetbrains-pycharm/.jetbrains:/home/projector-user -it registry.jetbrains.team/p/prj/containers/projector-pycharm-c
 
-      # Ultimate Edition
-      #sudo docker run --rm -p 8887:8887 -v /workspace/template-jetbrains-pycharm/.jetbrains:/home/projector-user -it registry.jetbrains.team/p/prj/containers/projector-pycharm-u
+      # Professional Edition
+      #sudo docker run --rm -p 8887:8887 -v /workspace/template-jetbrains-pycharm/.jetbrains:/home/projector-user -it registry.jetbrains.team/p/prj/containers/projector-pycharm-p
 
 ports:
   - port: 8887

--- a/README.md
+++ b/README.md
@@ -40,16 +40,16 @@ sudo docker run --rm -p 8887:8887 -v /workspace/template-jetbrains-pycharm/.jetb
 sudo docker run --rm -p 8887:8887 -v /workspace/my-jetbrains-repository/.jetbrains:/home/projector-user 
 ```
 
-### Community Edition & Ultimate Edition
+### Community Edition & Professional Edition
 
-By default the template is configured for the community edition. If you have licenses for the ultimate edition then adjust the [`.gitpod.yml`](./.gitpod.yml) as required:
+By default the template is configured for the community edition. If you have licenses for the professional edition then adjust the [`.gitpod.yml`](./.gitpod.yml) as required:
 
 ```yml
 # Community Edition
 # sudo docker run --rm -p 8887:8887 -it registry.jetbrains.team/p/prj/containers/projector-pycharm-c
 
 # Ultimate Edition
-sudo docker run --rm -p 8887:8887 -it registry.jetbrains.team/p/prj/containers/projector-pycharm-u
+sudo docker run --rm -p 8887:8887 -it registry.jetbrains.team/p/prj/containers/projector-pycharm-p
 ```
 
 


### PR DESCRIPTION
JetBrains no longer refers to it as "Ultimate" but rather "Professional" for the paid version, which changes the the image from `registry.jetbrains.team/p/prj/containers/projector-pycharm-u` to `registry.jetbrains.team/p/prj/containers/projector-pycharm-p`

I also updated other references from the word "Ultimate" to "Professional"